### PR TITLE
Rake test full

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,14 @@
 require "rake/testtask"
 
 Rake::TestTask.new do |t|
-  ENV['run_long_tests'] = (ARGV.include? 'full').to_s
+
+  if ARGV.include?('full')
+    ENV['run_long_tests'] = 'true'
+    t.verbose = true
+    task :full do end
+  end
+
   t.libs << "test"
   t.test_files = FileList['test/*.rb']
-  t.verbose = true
+
 end

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 require "rake/testtask"
 
 Rake::TestTask.new do |t|
+  ENV['run_long_tests'] = (ARGV.include? 'full').to_s
   t.libs << "test"
   t.test_files = FileList['test/*.rb']
   t.verbose = true

--- a/test/complete_me_test.rb
+++ b/test/complete_me_test.rb
@@ -298,6 +298,8 @@ class CompleteMeTest < Minitest::Test
 
 
   def test_all_features_with_large_dataset
+    long_running_test!
+
     dictionary = File.read("/usr/share/dict/words")
     cm.populate(dictionary)
     cm.select('me','meet')
@@ -319,6 +321,8 @@ class CompleteMeTest < Minitest::Test
   end
 
   def test_all_features_with_very_large_data_set
+    long_running_test!
+
     cm.populate_from_csv('./test/data/addresses.csv')
     cm.populate(File.read('./test/data/medium.txt'))
     cm.populate(File.read('/usr/share/dict/words'))
@@ -335,5 +339,9 @@ class CompleteMeTest < Minitest::Test
     assert cm.suggest('2525 W').include? '2525 Wewatta Way Unit 165'
 
     assert_equal cm.count, cm.suggest('').length
+  end
+
+  def long_running_test!
+    skip unless ENV['run_long_tests'] == 'true'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'simplecov'
 
-SimpleCov.add_filter /_test.rb$/
+SimpleCov.add_filter(/_test.rb$/)
 
 SimpleCov.start


### PR DESCRIPTION
With this commit, if you put `long_running_test!` in a test, it'll skip by default.
But if you run `rake test full` instead of `rake test`, it will run those tests.

I use ENV to communicate with the test from rake, which I wouldn't do in lib, but I think is more okay in test?